### PR TITLE
Kind mute sets

### DIFF
--- a/51.md
+++ b/51.md
@@ -48,6 +48,7 @@ Aside from their main identifier, the `"d"` tag, sets can optionally have a `"ti
 | Bookmark sets | 30003 | user-defined bookmarks categories , for when bookmarks must be in labeled separate groups    | `"e"` (kind:1 notes), `"a"` (kind:30023 articles), `"t"` (hashtags), `"r"` (URLs) |
 | Curation sets | 30004 | groups of articles picked by users as interesting and/or belonging to the same category      | `"a"` (kind:30023 articles), `"e"` (kind:1 notes)                                 |
 | Curation sets | 30005 | groups of videos picked by users as interesting and/or belonging to the same category        | `"a"` (kind:34235 videos)                                                         |
+| Kind mute sets | 30007 | mute pubkeys by kinds<br>`"d"` tag MUST be the kind string                                  | `"p"` (pubkeys)                                                                   |
 | Interest sets | 30015 | interest topics represented by a bunch of "hashtags"                                         | `"t"` (hashtags)                                                                  |
 | Emoji sets    | 30030 | categorized emoji groups                                                                     | `"emoji"` (see [NIP-30](30.md))                                                   |
 | Release artifact sets | 30063 | groups of files of a software release  | `"e"` (kind:1063 [file metadata](94.md) events), `"i"` (application identifier, typically reverse domain notation), `"version"`  |


### PR DESCRIPTION
Fix #1156

### JSON Example

```json
{
  "kind": 30007,
  "content": "<encrypted tags>",
  "tags": [
    ["d", "<kind>"],
    ["p", "<pubkey 1>"],
    ["p", "<pubkey 2>"]
  ]
}
```